### PR TITLE
Handle cleanup of state in certain scenario

### DIFF
--- a/lua/buffer-me/windower.lua
+++ b/lua/buffer-me/windower.lua
@@ -17,6 +17,7 @@ end
 function windower.close_window()
 	-- Clean up the state
 	state.bufNumToLineNumMap = {}
+	state.clear_selected_row()
 
 	-- Reset modifiable flag so the buffer can be updated on the next search
 	vim.api.nvim_buf_set_option(state.bufListBuf, "modifiable", true)


### PR DESCRIPTION
* In a particular case where the buffer window is opened and then closed, the selected row in the state would be set and not cleared. This would lead to a scenario where bufferme would try to close a window and cause an error
* Patching cleaning up the state better to fix this