### PR TITLE
Setting hotswap buffer window to inactive window

### DIFF
--- a/lua/buffer-me/windower.lua
+++ b/lua/buffer-me/windower.lua
@@ -32,7 +32,7 @@ function windower.render_buf_list_lines()
 end
 
 function windower.create_hot_swap_window()
-	return vim.api.nvim_open_win(state.hotswapBuf, true, {
+	return vim.api.nvim_open_win(state.hotswapBuf, false, {
 		relative = "editor",
 		row = 0,
 		col = 0,


### PR DESCRIPTION
Issue #10 

Fixing problem where opening the buffer window would reset which buffer was being selected after closing.